### PR TITLE
package.json의 repository 필드를 web-lab으로 수정합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "not-a-bean",
   "version": "0.1.0",
-  "repository": "https://github.com/binarysound/not-a-bean",
+  "repository": "https://github.com/binarysound/web-lab",
   "author": "binarysound",
   "license": "MIT",
   "private": false,


### PR DESCRIPTION
# 관련 이슈
Relates #25 

# 설명
저장소 이름을 `web-lab`으로 바꾸었기에 `package.json`에 표시된 GitHub repository 주소도 그에 맞게 업데이트합니다.