### PR TITLE
yarn-error.log를 .gitignore에 추가합니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 node_modules
+yarn-error.log


### PR DESCRIPTION
# 관련 이슈
Resolves #36 

# 설명
`yarn-error.log` 파일을 `.gitignore`에 추가합니다.