### PR TITLE
React Router를 셋업합니다.

### DIFF
--- a/app/client/actions/index.ts
+++ b/app/client/actions/index.ts
@@ -1,3 +1,5 @@
+import { RouterAction } from 'connected-react-router'
+
 import { IClientMessage, IServerMessage } from '@/models/network'
 
 export namespace AppAction {
@@ -21,5 +23,6 @@ export namespace AppAction {
 }
 
 export type AppAction =
+  RouterAction |
   AppAction.ENV_SAVE_SERVER_MESSAGE |
   AppAction.SAGA_PUSH_CLIENT_MESSAGE

--- a/app/client/containers/App.tsx
+++ b/app/client/containers/App.tsx
@@ -1,8 +1,9 @@
+import { ConnectedRouter } from 'connected-react-router'
 import React from 'react'
 import { Provider } from 'react-redux'
 
 import { TestContainer } from '@/client/containers/TestContainer'
-import { store } from '@/client/store'
+import { history, store } from '@/client/store'
 
 namespace App {
   /* tslint:disable-next-line:no-empty-interface */
@@ -17,7 +18,9 @@ export class App extends React.Component<App.IProps, App.IState> {
   public render() {
     return (
       <Provider store={store}>
-        <TestContainer />
+        <ConnectedRouter history={history}>
+          <TestContainer />
+        </ConnectedRouter>
       </Provider>
     )
   }

--- a/app/client/containers/TestContainer.tsx
+++ b/app/client/containers/TestContainer.tsx
@@ -1,9 +1,31 @@
+import { push } from 'connected-react-router'
 import React from 'react'
 import { connect, DispatchProp } from 'react-redux'
+import { Route, Switch } from 'react-router'
 
 import { AppAction } from '@/client/actions'
 import { IAppState } from '@/models/appState'
 import { IServerMessage } from '@/models/network'
+
+const Page = (props: {
+  dispatch: DispatchProp<AppAction>['dispatch'],
+  pageName: string,
+  toPageName: string,
+  toPath: string,
+}) => (
+  <div>
+    <div>{props.pageName}</div>
+    <div
+      style={{
+        color: 'blue',
+        cursor: 'pointer',
+      }}
+      onClick={() => props.dispatch(push(props.toPath))}
+    >
+      to {props.toPageName}
+    </div>
+  </div>
+)
 
 class _TestContainer extends React.Component<_TestContainer.IProps> {
   public componentDidMount() {
@@ -19,13 +41,54 @@ class _TestContainer extends React.Component<_TestContainer.IProps> {
   }
 
   public render() {
-    const { serverMessage } = this.props
-    return <div>{serverMessage.body}</div>
+    const { serverMessage, dispatch } = this.props
+    return (
+      <div>
+        {serverMessage.body}
+        <Switch>
+          <Route
+            path='/'
+            exact={true}
+            render={() => (
+              <Page
+                dispatch={dispatch}
+                pageName='Main page'
+                toPageName='Another page'
+                toPath='/another'
+              />
+            )}
+          />
+          <Route
+            path='/another'
+            exact={true}
+            render={() => (
+              <Page
+                dispatch={dispatch}
+                pageName='Another page'
+                toPageName='Main page'
+                toPath='/'
+              />
+            )}
+          />
+          <Route
+            render={() => (
+              <Page
+                dispatch={dispatch}
+                pageName='404'
+                toPageName='Main page'
+                toPath='/'
+              />
+            )}
+          />
+        </Switch>
+      </div>
+    )
   }
 }
 
 namespace _TestContainer {
   export interface IPropsFromState {
+    currentPath: string  // prop to force rerender when path changes
     serverMessage: IServerMessage
   }
   /* tslint:disable-next-line:no-empty-interface */
@@ -35,6 +98,7 @@ namespace _TestContainer {
 
   export function mapStateToProps(state: IAppState): IPropsFromState {
     return {
+      currentPath: state.router.location.pathname,
       serverMessage: state.env.serverMessage,
     }
   }

--- a/app/client/containers/__snapshots__/App.spec.tsx.snap
+++ b/app/client/containers/__snapshots__/App.spec.tsx.snap
@@ -3,5 +3,22 @@
 exports[`App renders correctly 1`] = `
 <div>
   No message received.
+  <div>
+    <div>
+      Main page
+    </div>
+    <div
+      onClick={[Function]}
+      style={
+        Object {
+          "color": "blue",
+          "cursor": "pointer",
+        }
+      }
+    >
+      to 
+      Another page
+    </div>
+  </div>
 </div>
 `;

--- a/app/client/store.ts
+++ b/app/client/store.ts
@@ -1,18 +1,21 @@
+import { connectRouter, routerMiddleware } from 'connected-react-router'
+import { createBrowserHistory } from 'history'
 import { applyMiddleware, createStore } from 'redux'
 import { composeWithDevTools } from 'redux-devtools-extension'
 import createSagaMiddleware from 'redux-saga'
 
-import { AppAction } from '@/client/actions'
 import reducer from '@/client/reducers'
 import rootSaga from '@/client/sagas'
-import { IAppState } from '@/models/appState'
+
+export const history = createBrowserHistory()
 
 const sagaMiddleware = createSagaMiddleware()
 
-export const store = createStore<IAppState, AppAction, {}, {}>(
-  reducer,
+export const store = createStore(
+  connectRouter(history)(reducer),
   composeWithDevTools(
     applyMiddleware(
+      routerMiddleware(history),
       sagaMiddleware,
     ),
   ),

--- a/app/models/appState.ts
+++ b/app/models/appState.ts
@@ -1,3 +1,5 @@
+import { RouterState } from 'connected-react-router'
+
 import { IServerMessage } from '@/models/network'
 
 export namespace AppState {
@@ -8,4 +10,5 @@ export namespace AppState {
 
 export interface IAppState {
   env: AppState.IEnv
+  router: RouterState
 }

--- a/app/server/index.ts
+++ b/app/server/index.ts
@@ -1,13 +1,16 @@
 import express from 'express'
+import fallback from 'express-history-api-fallback'
 import http from 'http'
 import SocketIO from 'socket.io'
 
 import { IClientMessage, IServerMessage } from '@/models/network'
 
 const PORT = process.env.PORT || 5000
-const app = express()
+const root = 'build/client'
 
-app.use(express.static('build/client'))
+const app = express()
+app.use(express.static(root))
+app.use(fallback('index.html', { root }))
 
 const server = http.createServer(app)
 

--- a/app/server/tsconfig.json
+++ b/app/server/tsconfig.json
@@ -4,6 +4,7 @@
         "module": "commonjs"
     },
     "include": [
-        "./**/*"
+        "./**/*",
+        "../../index.d.ts"
     ]
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+declare module 'express-history-api-fallback' {
+  import { Handler } from 'express'
+  function fallback(indexPath: string, options: { root: string }): Handler
+  export default fallback
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/react-router": "^4.0.31",
     "connected-react-router": "^4.5.0",
     "express": "^4.16.3",
+    "express-history-api-fallback": "^2.2.1",
     "immer": "^1.6.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,14 @@
     "webpack-node-externals": "^1.7.2"
   },
   "dependencies": {
+    "@types/react-router": "^4.0.31",
+    "connected-react-router": "^4.5.0",
     "express": "^4.16.3",
     "immer": "^1.6.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-redux": "^5.0.7",
+    "react-router": "^4.3.1",
     "redux": "^4.0.0",
     "redux-devtools-extension": "^2.13.5",
     "redux-saga": "^0.16.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,7 @@ module.exports = (env, argv) => {
       path: path.resolve(__dirname, `build/${target}`),
       filename: '[name].bundle.js',
       chunkFilename: '[name].bundle.js',
+      publicPath: '/',
     },
     module: {
       rules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,10 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/history@*":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.0.tgz#2fac51050c68f7d6f96c5aafc631132522f4aa3f"
+
 "@types/jest@^23.3.2":
   version "23.3.2"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.2.tgz#07b90f6adf75d42c34230c026a2529e56c249dbb"
@@ -84,6 +88,13 @@
   dependencies:
     "@types/react" "*"
     redux "^4.0.0"
+
+"@types/react-router@^4.0.31":
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.31.tgz#416bac49d746800810886c7b8582a622ed9604fc"
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react-test-renderer@^16.0.2":
   version "16.0.2"
@@ -1103,6 +1114,14 @@ configstore@^3.0.0:
     unique-string "^1.0.0"
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
+
+connected-react-router@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/connected-react-router/-/connected-react-router-4.5.0.tgz#b6f021cc284a244fbee70e16e5ff0f2a4613e3d3"
+  dependencies:
+    immutable "^3.8.1"
+    redux-seamless-immutable "^0.4.0"
+    seamless-immutable "^7.1.3"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -2199,6 +2218,16 @@ he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
 
+history@^4.7.2:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"
+  dependencies:
+    invariant "^2.2.1"
+    loose-envify "^1.2.0"
+    resolve-pathname "^2.2.0"
+    value-equal "^0.4.0"
+    warning "^3.0.0"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -2329,6 +2358,10 @@ immer@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.6.0.tgz#4e41801272d64bff12d4b58ada0276bb2f4ead81"
 
+immutable@^3.8.1:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -2389,7 +2422,7 @@ interpret@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.0.0, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.0.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -3228,7 +3261,7 @@ long@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/long/-/long-3.2.0.tgz#d821b7138ca1cb581c172990ef14db200b5c474b"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -3924,6 +3957,12 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  dependencies:
+    isarray "0.0.1"
+
 path-type@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-1.1.0.tgz#59c44f7ee491da704da415da5a4070ba4f8fe441"
@@ -4033,7 +4072,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.6.0, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -4191,6 +4230,22 @@ react-redux@^5.0.7:
     loose-envify "^1.1.0"
     prop-types "^15.6.0"
 
+react-router-redux@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
+
+react-router@^4.3.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-4.3.1.tgz#aada4aef14c809cb2e686b05cee4742234506c4e"
+  dependencies:
+    history "^4.7.2"
+    hoist-non-react-statics "^2.5.0"
+    invariant "^2.2.4"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.1"
+    warning "^4.0.1"
+
 react-test-renderer@^16.5.0:
   version "16.5.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.5.0.tgz#1aeca0edc4f27f63265dcaed80ba82e11e762f56"
@@ -4267,6 +4322,13 @@ redux-devtools-extension@^2.13.5:
 redux-saga@*, redux-saga@^0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
+
+redux-seamless-immutable@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/redux-seamless-immutable/-/redux-seamless-immutable-0.4.0.tgz#b50f8680ecc5ef04021551267f78fa1ffd3cf985"
+  dependencies:
+    react-router-redux "^4.0.0"
+    seamless-immutable "^7.1.2"
 
 redux@*, redux@^4.0.0:
   version "4.0.0"
@@ -4394,6 +4456,10 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-pathname@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-2.2.0.tgz#7e9ae21ed815fd63ab189adeee64dc831eefa879"
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -4503,6 +4569,10 @@ schema-utils@^0.4.4, schema-utils@^0.4.5:
   dependencies:
     ajv "^6.1.0"
     ajv-keywords "^3.1.0"
+
+seamless-immutable@^7.1.2, seamless-immutable@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -5325,6 +5395,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+value-equal@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-0.4.0.tgz#c5bdd2f54ee093c04839d71ce2e4758a6890abc7"
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
@@ -5354,6 +5428,18 @@ walker@~1.0.5:
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.7.tgz#2f7f9b8fd10d677262b18a884e28d19618e028fb"
   dependencies:
     makeerror "1.0.x"
+
+warning@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  dependencies:
+    loose-envify "^1.0.0"
 
 watch@~0.18.0:
   version "0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1742,6 +1742,10 @@ expect@^23.5.0:
     jest-message-util "^23.4.0"
     jest-regex-util "^23.3.0"
 
+express-history-api-fallback@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/express-history-api-fallback/-/express-history-api-fallback-2.2.1.tgz#3a2ad27f7bebc90fc533d110d7c6d83097bcd057"
+
 express@^4.16.3:
   version "4.16.3"
   resolved "http://registry.npmjs.org/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"


### PR DESCRIPTION
# 관련 이슈
Closes #14 

# 설명
- client-side routing을 셋업합니다.
  - React Router를 추가합니다.
    - [connected-react-router](https://github.com/supasate/connected-react-router)를 통해 Redux와도 연동합니다.
  - history API fallback을 지원합니다.
- `TestContainer`에 활용 예시를 추가합니다.

# 스크린샷
![image](https://user-images.githubusercontent.com/11784631/46027867-e84d4c80-c129-11e8-97bc-64e79032bde1.png)

![image](https://user-images.githubusercontent.com/11784631/46027882-f0a58780-c129-11e8-823e-f5bcd15ce3c0.png)

![image](https://user-images.githubusercontent.com/11784631/46027888-fa2eef80-c129-11e8-9277-87fc4b855351.png)
