### PR TITLE
개발 환경을 dockerize 합니다.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.env
+build
+node_modules
+yarn-error.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 build
 node_modules
 yarn-error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8.11.4
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.9.4
+
+ENV PORT=5000
+
+RUN mkdir /build
+WORKDIR /build
+COPY package.json yarn.lock docker-entry.sh ./
+
+RUN /root/.yarn/bin/yarn install
+RUN chmod 744 docker-entry.sh
+
+CMD ./docker-entry.sh

--- a/README.md
+++ b/README.md
@@ -2,10 +2,19 @@
 각종 웹 서비스의 빠른 프로토타이핑을 위한 저장소입니다.
 
 ## 개발
-Node 8 이상이 필요합니다.
-다음 명령으로 서버를 실행할 수 있습니다.
+[Docker](https://www.docker.com/products/docker-desktop)가 필요합니다.
 ```bash
-yarn run dev  # 서버 & 클라이언트 watch 및 실행
+export PORT=5000
+docker-compose up --build  # 디펜던시 업데이트가 필요한 경우
+docker-compose up          # 디펜던시 업데이트가 없는 경우
+```
+
+이후 `localhost:5000`을 브라우저로 방문해 봅니다.
+
+### 환경변수
+Docker는 [`.env` 파일을 감지하여 환경변수로 사용](https://docs.docker.com/compose/environment-variables/#the-env-file)합니다. 프로젝트 루트에 `.env` 파일을 다음과 같이 생성해두면 매번 환경변수를 설정하지 않아도 됩니다.
+```bash
+PORT=5000
 ```
 
 ## 배포

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+  web:
+    build: .
+    ports:
+      - "${PORT}:5000"
+    volumes:
+      - .:/code

--- a/docker-entry.sh
+++ b/docker-entry.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+export PATH="/root/.yarn/bin:/root/.config/yarn/global/node_modules/.bin:$PATH"
+
+cd /code
+
+if [ -d "node_modules" ]; then
+    echo "node_modules already exists. Verifying tree..."
+    yarn check --verify-tree
+    if [ $? -ne 0 ]; then
+        echo "node_modules does not match package.json. Removing..."
+        rm -rf node_modules
+        echo "Copying node_modules..."
+        cp -r /build/node_modules .
+    fi
+else
+    echo "Coyping node_modules..."
+    cp -r /build/node_modules .
+fi
+
+yarn run dev


### PR DESCRIPTION
# 관련 이슈
Closes #17 

# 설명
모든 개발자가 동일한 개발 환경에서 작업할 수 있도록 개발 환경을 dockerize 합니다. 이제 `docker-compose up` 명령어로 항상 일정한 환경에서 개발할 수 있습니다.

## 테스트
```bash
touch .env
echo "PORT=5000" >> .env   # 5000번 포트에 앱을 띄웁니다. 
docker-compose up --build  # 이미지를 신규 빌드하고 컨테이너를 띄웁니다.
```

브라우저로 `localhost:5000`에 접속해봅니다. 프로젝트 디렉토리를 컨테이너 내부에 바인딩해 `devRun.js` 스크립트를 실행하기 때문에, 호스트에서 서버나 클라이언트 코드를 바꾸면 자동으로 동작이 갱신됩니다.

동작을 확인한 후 Ctrl+C로 컨테이너를 종료합니다.

`docker-compose ps`를 통해 현재 컨테이너의 상태를 확인할 수 있습니다.

```plain
    Name                  Command               State     Ports
---------------------------------------------------------------
web-lab_web_1   /bin/sh -c ./docker-entry.sh   Exit 137
```

다른 방식으로 컨테이너를 띄워보겠습니다. `-d` 플래그를 주면 detached mode로 컨테이너를 띄울 수 있습니다.

```bash
docker-compose up -d    # detached 상태로 컨테이너를 띄웁니다.
docker-compose logs -f  # 컨테이너 로그를 follow합니다.
```

`docker-compose ps`를 해 보면, 이제는 `up` 상태인 것을 볼 수 있습니다.

```plain
    Name                  Command              State           Ports
-----------------------------------------------------------------------------
web-lab_web_1   /bin/sh -c ./docker-entry.sh   Up      0.0.0.0:5000->5000/tcp
```

마지막으로, `docker-compose down`은 컨테이너를 종료하고 삭제합니다. 컨테이너 삭제 없이 종료만을 원한다면 `docker-compose stop`을 사용합니다.

## 참고 자료
- https://zzz.buzz/2018/05/23/differences-of-rules-between-gitignore-and-dockerignore/
