### PR TITLE
Redux action interface IBase의 속성들을 readonly로 만듭니다.

### DIFF
--- a/app/client/actions/index.ts
+++ b/app/client/actions/index.ts
@@ -9,8 +9,8 @@ export namespace AppAction {
   }
 
   export interface IBase<A extends Type, P extends object> {
-    type: A
-    payload: P
+    readonly type: A
+    readonly payload: P
   }
 
   export type ENV_SAVE_SERVER_MESSAGE = IBase<Type.ENV_SAVE_SERVER_MESSAGE, {


### PR DESCRIPTION
# 관련 이슈
Closes #47 

# 설명
안전한 action 관리를 위해 속성들을 `readonly` 처리합니다.